### PR TITLE
[Feat] RestTemplate 예외 처리 설정

### DIFF
--- a/src/main/java/com/developers/solve/config/RestTemplateConfig.java
+++ b/src/main/java/com/developers/solve/config/RestTemplateConfig.java
@@ -1,13 +1,21 @@
 package com.developers.solve.config;
 
+import com.developers.solve.exception.RestTemplateResponseErrorHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+
+/**
+ * restTemplate()
+ * RestTemplate 빈을 등록해두고 커스텀 예외 클래스를 주입받아서 예외 처리 진행
+ */
 
 @Configuration
 public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new RestTemplateResponseErrorHandler());
+        return restTemplate;
     }
 }

--- a/src/main/java/com/developers/solve/config/RestTemplateConfig.java
+++ b/src/main/java/com/developers/solve/config/RestTemplateConfig.java
@@ -1,9 +1,13 @@
 package com.developers.solve.config;
 
 import com.developers.solve.exception.RestTemplateResponseErrorHandler;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
 
 /**
  * restTemplate()
@@ -13,9 +17,11 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
     @Bean
-    public RestTemplate restTemplate() {
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.setErrorHandler(new RestTemplateResponseErrorHandler());
-        return restTemplate;
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .errorHandler(new RestTemplateResponseErrorHandler())
+                .build();
     }
 }

--- a/src/main/java/com/developers/solve/exception/RestTemplateResponseErrorHandler.java
+++ b/src/main/java/com/developers/solve/exception/RestTemplateResponseErrorHandler.java
@@ -1,0 +1,30 @@
+package com.developers.solve.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+
+@Component
+public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        HttpStatus statusCode = (HttpStatus) response.getStatusCode();
+        // HTTP 응답 코드가 4xx나 5xx인 경우 예외 상황으로 간주합니다.
+        return statusCode.is4xxClientError() || statusCode.is5xxServerError();
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+        HttpStatus statusCode = (HttpStatus) response.getStatusCode();
+        // HTTP 응답 코드가 4xx나 5xx인 경우 처리할 수 있습니다.
+        if(statusCode.series() == HttpStatus.Series.SERVER_ERROR) {
+            // handle SERVER_ERROR
+        } else if(statusCode.series() == HttpStatus.Series.CLIENT_ERROR) {
+            // handle CLIENT_ERROR
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Motivation
- RestTemplate 설정에 필요한 예외 처리 로직을 추가

<br>

## 💡 Key Changes
- `ResponseErrorHandler` 인터페이스의 구현체 클래스 `RestTemplateResponseErrorHandler`를 새로 정의하였습니다. 해당 클래스에서는 기본 오류에 대한 예외 처리를 할 수 있도록 분기점을 지정해놓았습니다. 이후 필요한 예외처리가 있다면 해당 클래스에 추가하면 됩니다.
- RestTemplate을 스프링 빈으로 등록해두는데 이 때, `RestTemplateBuilder`를 통해 타임아웃, 예외 처리 핸들링을 설정할 수 있습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @ITfervor @EagerProgrammer 
